### PR TITLE
Change `base_url` in `config.toml` to `ihatereality.space`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://iloathereality.github.io"
+base_url = "https://ihatereality.space"
 title = "I hate reality"
 
 # Whether to automatically compile all Sass files in the sass directory


### PR DESCRIPTION
Previously https://iloathereality.github.io was used.

Since I've renamed this repo to _blog_, https://iloathereality.github.io is not reachable anymore.