### PR TITLE
Use "summary" instead of "summary_large_image" for twitter preview

### DIFF
--- a/themes/terminimal/templates/index.html
+++ b/themes/terminimal/templates/index.html
@@ -25,7 +25,7 @@
     <meta property="og:locale" content="{{lang}}">
 
     <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary">
     <meta property="twitter:domain" content="{{config.extra.domain}}">
     <meta property="twitter:url" content="{{section.permalink | safe}}">
     <meta name="twitter:title" content="{{section.title}}">

--- a/themes/terminimal/templates/page.html
+++ b/themes/terminimal/templates/page.html
@@ -31,7 +31,7 @@
     {% endif %}
 
     <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary">
     <meta property="twitter:domain" content="{{config.extra.domain}}">
     <meta property="twitter:url" content="{{page.permalink | safe}}">
     <meta name="twitter:title" content="{{page.title}}">


### PR DESCRIPTION
With this PR I'm (hopefully) done with previews/social meta tags.

Related PRs:
- https://github.com/iloathereality/blog/pull/19
- https://github.com/iloathereality/blog/pull/20
- https://github.com/iloathereality/blog/pull/21

Preview will approximately look like this:

Twitter:
![image](https://user-images.githubusercontent.com/38225716/133940109-cc0a5f7e-fcc3-4eb8-852c-e1519624da4e.png)
Discord:
![image](https://user-images.githubusercontent.com/38225716/133940115-5bd39ec7-49bc-43ed-9c46-f761c2d4cfb0.png)
Telegram:
![image](https://user-images.githubusercontent.com/38225716/133940148-65124907-3324-440a-8211-36c39e0833d2.png)

In conclusion: I want to die now