### PR TITLE
Improve tags look

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,14 +50,11 @@ menu_items = [
     # $BASE_URL is going to be substituted by base_url from configuration
     #{name = "blog", url = "$BASE_URL"},
     
-    
     # # May be desired in future
     #{name = "archive", url = "$BASE_URL/archive"},
+    #{name = "tags", url = "$BASE_URL/tags"},
 
     {name = "about", url = "$BASE_URL/about"},
-    
-    {name = "tags", url = "$BASE_URL/tags"},
-
     {name = "source", url = "https://github.com/iloathereality/blog", newtab = true},
 ]
 

--- a/themes/terminimal/sass/post.scss
+++ b/themes/terminimal/sass/post.scss
@@ -51,6 +51,11 @@
   %tags {
     margin-bottom: 20px;
     font-size: 1rem;
+    color: var(--color);
+    opacity: .5;
+    a {
+      text-decoration: none;
+    }
   }
 
   &-tags {
@@ -148,12 +153,8 @@
   a {
     text-decoration: none;
   }
+}
 
-  .post-list-title {
-    text-decoration: underline;
-  }
-
-  .post-tag {
-    text-decoration: underline;
-  }
+ul li.tag-list a {
+  text-decoration: none;
 }

--- a/themes/terminimal/templates/tags/list.html
+++ b/themes/terminimal/templates/tags/list.html
@@ -10,7 +10,7 @@
             {% for term in terms %}
             <li class="tag-list">
                 <a href="{{ term.permalink | safe }}">
-                    {{ term.name }} ({{ term.pages | length }} post{{ term.pages | length | pluralize }})
+                    {{ term.name }} ({{ term.pages | length }})
                 </a>
             </li>
             {% endfor %}

--- a/themes/terminimal/templates/tags/single.html
+++ b/themes/terminimal/templates/tags/single.html
@@ -6,7 +6,7 @@
     <div class="post">
         <h1 class="post-title">
             tag: #{{ term.name }}
-            ({{ term.pages | length }} post{{ term.pages | length | pluralize }})
+            ({{ term.pages | length }})
         </h1>
 
         <a href="{{ config.base_url | safe }}/tags">


### PR DESCRIPTION
- Remove the word "post(s)" from the tags list
- Remove "tags" from the menu
- Remove the word "post(s)" from the single tag list
- Remove underling for tags
- Make tags less bright
