### PR TITLE
Change h{1,2,3} and <code> styling

### DIFF
--- a/content/ff-test.md
+++ b/content/ff-test.md
@@ -60,6 +60,12 @@ struct Ugh;
 fn test<'a, T: ?Sized + 'a>(_: &T, _ugh: &'a Ugh) -> () {}
 ```
 
+# Header one
+## Header two
+### Header three
+
+---
+
 ### djddcj
 
 Unmono `monomono mono` unmono `a litle bit more mono` djceje;cvj;ecj `Option<T>` option.

--- a/themes/terminimal/sass/main.scss
+++ b/themes/terminimal/sass/main.scss
@@ -35,15 +35,15 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  font-size: 1.4rem;
+  font-size: 1.8rem;
 }
 
 h2 {
-  font-size: 1.3rem;
+  font-size: 1.4rem;
 }
 
 h3 {
-  font-size: 1.2rem;
+  font-size: 1.25rem;
 }
 
 h4, h5, h6 {
@@ -128,16 +128,10 @@ code {
   background: var(--accent-alpha-20);
   margin: 0;
   padding: 2px 4px;
-  font-size: .95rem;
+  font-size: .95em;
   border-radius: 6px;
+  white-space: nowrap;
 }
-
-h1, h2, h3, h4, h5, h6 {
-  code {
-    font-size: inherit;
-  }
-}
-
 
 pre {
   position: relative;
@@ -167,6 +161,7 @@ pre {
     background: none;
     font-size: inherit;
     overflow: auto;
+    white-space: unset;
   }
 
   @media (max-width: $phone-max-width) {


### PR DESCRIPTION
- Make h* bigger and more different
  1. 1.4 rem -> 1.8 rem
  2. 1.3 rem -> 1.4 rem
  3. 1.2 rem -> 1.25 rem
- Disable wrapping for `<code>`
- Remove `h* code` `font-size` workaround and just make `code` font size relative to the parent
