### PR TITLE
Add tracking via goatcounter

### DIFF
--- a/themes/terminimal/templates/index.html
+++ b/themes/terminimal/templates/index.html
@@ -139,6 +139,9 @@
     {% endblock footer %}
 
 </div>
+
+<!-- Tracking via https://www.goatcounter.com/ -->
+<script data-goatcounter="https://ihr.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
[Goatcounter] was chosen because it's open-source and seems more lightweight/moral than alternatives.

Also, since it's [recomended by Amos][rec].

[Goatcounter]: https://www.goatcounter.com/
[rec]: https://twitter.com/fasterthanlime/status/1454106492752343041
