### PR TITLE
Remove `code { white-space: nowrap }` to fix mobile rendering

### DIFF
--- a/themes/terminimal/sass/main.scss
+++ b/themes/terminimal/sass/main.scss
@@ -130,7 +130,6 @@ code {
   padding: 2px 4px;
   font-size: .95em;
   border-radius: 6px;
-  white-space: nowrap;
 }
 
 pre {


### PR DESCRIPTION
This should fix the following problem on mobile:
![image](https://user-images.githubusercontent.com/38225716/151706977-f30d9c82-062d-480f-8df0-78337cbc5a77.png)
