### PR TITLE
Hide devlogs by default & add a button to show them

### DIFF
--- a/themes/terminimal/sass/devlog.scss
+++ b/themes/terminimal/sass/devlog.scss
@@ -1,0 +1,29 @@
+// Make a button that looks like [show devlogs] (when unpressed) or [hide devlogs] (when pressed)
+// and does what it says. (also it's `opacity: .5` so that it's not too bright)
+input[type=checkbox]#show-devlog {
+    display: none;
+}
+
+input[type=checkbox]#show-devlog+label {
+    color: var(--color);
+    opacity: .5;
+}
+
+input[type=checkbox]#show-devlog+label::before {
+    content: "[show devlogs]";
+}
+
+input[type=checkbox]#show-devlog:checked+label::before {
+    content: "[hide devlogs]";
+}
+
+// Hide all devlog entries by default
+div.on-list.devlog {
+    display: none;
+}
+
+// Show devlog entries if the checkbox in the header is checked
+header:has(#show-devlog:checked)+div.content div.on-list.devlog {
+    // This should be changed to `list-item` once the post list is a list
+    display: block;
+}

--- a/themes/terminimal/sass/style.scss
+++ b/themes/terminimal/sass/style.scss
@@ -6,4 +6,5 @@
 @import 'post';
 @import 'pagination';
 @import 'footer';
-@import 'callout'
+@import 'callout';
+@import 'devlog';

--- a/themes/terminimal/templates/index.html
+++ b/themes/terminimal/templates/index.html
@@ -72,7 +72,9 @@
             </div>
         </div>
 
-        {{ menu_macros::menu(config=config, current_path=current_path) }}
+        {% block menu %}
+            {{ menu_macros::menu(config=config, current_path=current_path, show_show_devlog_checkbox=true) }}
+        {% endblock menu %}
     </header>
     {% endblock header %}
 
@@ -86,10 +88,17 @@
             {% endif -%}
 
             {%- for page in show_pages %}
-                <div class="post on-list">
-                    {{ post_macros::header(page=page) }}
-                    {{ post_macros::content(page=page, summary=true) }}
-                </div>
+                {%- if page.taxonomies.tags is containing("devlog") %}
+                    <div class="post on-list devlog">
+                        {{ post_macros::header(page=page) }}
+                        {{ post_macros::content(page=page, summary=true) }}
+                    </div>
+                {% else %}
+                    <div class="post on-list">
+                        {{ post_macros::header(page=page) }}
+                        {{ post_macros::content(page=page, summary=true) }}
+                    </div>
+                {% endif -%}
             {% endfor -%}
             <div class="pagination">
                 <div class="pagination__buttons">

--- a/themes/terminimal/templates/macros/menu.html
+++ b/themes/terminimal/templates/macros/menu.html
@@ -1,4 +1,4 @@
-{% macro menu(config, current_path) %}
+{% macro menu(config, current_path, show_show_devlog_checkbox) %}
     {%- if config.extra.menu_items %}
         {%- set menu_items = config.extra.menu_items -%}
 
@@ -36,6 +36,13 @@
                     {%- endif -%}
                 </li>
             {% endfor -%}
+
+            {%- if show_show_devlog_checkbox %}
+                <li>
+                    <input type="checkbox" id="show-devlog" name="show-devlog" />
+                    <label for="show-devlog"><!-- text is added by css --></label>
+                </li>
+            {% endif -%}
             </ul>
         </nav>
     {% endif -%}

--- a/themes/terminimal/templates/page.html
+++ b/themes/terminimal/templates/page.html
@@ -40,6 +40,10 @@
     <meta name="twitter:creator" content="{{config.extra.twitter_creator_username}}">
 {% endblock social_metatags %}
 
+{% block menu %}
+    {{ menu_macros::menu(config=config, current_path=current_path, show_show_devlog_checkbox=false) }}
+{% endblock menu %}
+
 {% block content %}
     <div class="post">
         {{ post_macros::header(page=page) }}


### PR DESCRIPTION
I wanted to do this for the longest time -- it was always bugging me that devlogs use all the space (there are more devlogs than posts and I recently haven't published any posts). 